### PR TITLE
Timeout strategy

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,17 +16,18 @@ type Config struct {
 	// the final level.
 	ContributionsPerc int
 
+	// UpdatePeriod indicates at which frequency a Handel nodes sends updates
+	// about its state to other Handel nodes.
+	UpdatePeriod time.Duration
+
+	// UpdateCount indicates the number of nodes contacted during each update at
+	// a given level.
+	UpdateCount int
+
 	// CandidateCount indicates how many peers should we contact each time we
 	// send packets to Handel nodes in a given candidate set. New nodes are
 	// selected each time but no more than CandidateCount.
 	CandidateCount int
-
-	// LevelTimeout Bla bla bla
-	LevelTimeout time.Duration
-
-	// UpdatePeriod indicates at which frequency a Handel nodes sends updates
-	// about its state to other Handel nodes.
-	UpdatePeriod time.Duration
 
 	// NewBitSet returns an empty bitset. This function is used to parse
 	// incoming packets containing bitsets.
@@ -52,11 +53,11 @@ func DefaultConfig(size int) *Config {
 		ContributionsPerc:    DefaultContributionsPerc,
 		CandidateCount:       DefaultCandidateCount,
 		UpdatePeriod:         DefaultUpdatePeriod,
+		UpdateCount:          DefaultUpdateCount,
 		NewBitSet:            DefaultBitSet,
 		NewPartitioner:       DefaultPartitioner,
 		NewEvaluatorStrategy: DefaultEvaluatorStrategy,
 		NewTimeoutStrategy:   DefaultTimeoutStrategy,
-		LevelTimeout:         DefaultLevelTimeout,
 	}
 }
 
@@ -69,6 +70,10 @@ const DefaultCandidateCount = 10
 
 // DefaultUpdatePeriod is the default update period used by Handel.
 const DefaultUpdatePeriod = 20 * time.Millisecond
+
+// DefaultUpdateCount is the default number of candidate contacted during an
+// update
+const DefaultUpdateCount = 10
 
 // DefaultBitSet returns the default implementation used by Handel, i.e. the
 // WilffBitSet
@@ -111,6 +116,9 @@ func mergeWithDefault(c *Config, size int) *Config {
 	if c.UpdatePeriod == 0*time.Second {
 		c2.UpdatePeriod = DefaultUpdatePeriod
 	}
+	if c.UpdateCount == 0 {
+		c2.UpdateCount = DefaultUpdateCount
+	}
 	if c.NewBitSet == nil {
 		c2.NewBitSet = DefaultBitSet
 	}
@@ -122,9 +130,6 @@ func mergeWithDefault(c *Config, size int) *Config {
 	}
 	if c.NewTimeoutStrategy == nil {
 		c2.NewTimeoutStrategy = DefaultTimeoutStrategy
-	}
-	if c.LevelTimeout == 0*time.Second {
-		c2.LevelTimeout = DefaultLevelTimeout
 	}
 	return &c2
 }

--- a/config.go
+++ b/config.go
@@ -24,10 +24,10 @@ type Config struct {
 	// a given level.
 	UpdateCount int
 
-	// CandidateCount indicates how many peers should we contact each time we
+	// NodeCount indicates how many peers should we contact each time we
 	// send packets to Handel nodes in a given candidate set. New nodes are
-	// selected each time but no more than CandidateCount.
-	CandidateCount int
+	// selected each time but no more than NodeCount.
+	NodeCount int
 
 	// NewBitSet returns an empty bitset. This function is used to parse
 	// incoming packets containing bitsets.
@@ -44,14 +44,14 @@ type Config struct {
 
 	// NewTimeoutStrategy returns the Timeout strategy to use during the Handel
 	// round. By default, it uses the linear timeout strategy.
-	NewTimeoutStrategy func(*Handel) TimeoutStrategy
+	NewTimeoutStrategy func(h *Handel, levels []int) TimeoutStrategy
 }
 
 // DefaultConfig returns a default configuration for Handel.
 func DefaultConfig(size int) *Config {
 	return &Config{
 		ContributionsPerc:    DefaultContributionsPerc,
-		CandidateCount:       DefaultCandidateCount,
+		NodeCount:            DefaultCandidateCount,
 		UpdatePeriod:         DefaultUpdatePeriod,
 		UpdateCount:          DefaultUpdateCount,
 		NewBitSet:            DefaultBitSet,
@@ -93,8 +93,8 @@ var DefaultEvaluatorStrategy = func(store signatureStore, h *Handel) SigEvaluato
 
 // DefaultTimeoutStrategy returns the default timeout strategy used by handel -
 // the linear strategy with the default timeout. See DefaultLevelTimeout.
-func DefaultTimeoutStrategy(h *Handel) TimeoutStrategy {
-	return NewDefaultLinearTimeout(h)
+func DefaultTimeoutStrategy(h *Handel, levels []int) TimeoutStrategy {
+	return NewDefaultLinearTimeout(h, levels)
 }
 
 // ContributionsThreshold returns the threshold of contributions required in a
@@ -110,8 +110,8 @@ func mergeWithDefault(c *Config, size int) *Config {
 	if c.ContributionsPerc == 0 {
 		c2.ContributionsPerc = DefaultContributionsPerc
 	}
-	if c.CandidateCount == 0 {
-		c2.CandidateCount = DefaultCandidateCount
+	if c.NodeCount == 0 {
+		c2.NodeCount = DefaultCandidateCount
 	}
 	if c.UpdatePeriod == 0*time.Second {
 		c2.UpdatePeriod = DefaultUpdatePeriod

--- a/config.go
+++ b/config.go
@@ -73,7 +73,7 @@ const DefaultUpdatePeriod = 20 * time.Millisecond
 
 // DefaultUpdateCount is the default number of candidate contacted during an
 // update
-const DefaultUpdateCount = 10
+const DefaultUpdateCount = 1
 
 // DefaultBitSet returns the default implementation used by Handel, i.e. the
 // WilffBitSet

--- a/handel.go
+++ b/handel.go
@@ -305,15 +305,9 @@ func (h *Handel) StartLevel(level int) {
 	h.sendUpdate(lvl, h.c.NodeCount)
 }
 
-// Send our best signature set for this level, to 'count' nodes
+// Send our best signature set for this level, to 'count' nodes. The level must
+// be active before calling this method.
 func (h *Handel) sendUpdate(l *level, count int) {
-	if !l.started() {
-		panic("level not started!")
-	}
-	if !l.active() {
-		return
-	}
-
 	sp := h.store.Combined(byte(l.id) - 1)
 	newNodes, _ := l.selectNextPeers(count)
 	h.sendTo(l.id, sp, newNodes)

--- a/handel.go
+++ b/handel.go
@@ -255,7 +255,6 @@ func (h *Handel) Start() {
 	go h.rangeOnVerified()
 	go h.timeout.Start()
 	go h.periodicLoop()
-	//h.periodicUpdate()
 }
 
 func (h *Handel) periodicLoop() {
@@ -284,23 +283,14 @@ func (h *Handel) Stop() {
 func (h *Handel) periodicUpdate() {
 	for i := byte(1); i <= byte(len(h.levels)); i++ {
 		lvl := h.getLevel(i)
-		//if !lvl.sendStarted {
-		//h.decideToStartLevel(lvl)
-		//}
 		if lvl.active() {
-			h.sendUpdate(lvl, 1)
+			h.sendUpdate(lvl, h.c.UpdateCount)
 		}
 	}
 }
 
-func (h *Handel) decideToStartLevel(l *level) {
-	msSinceStart := int(time.Now().Sub(h.startTime).Seconds() * 1000)
-	if msSinceStart >= l.id*int(h.c.LevelTimeout.Seconds())*1000 {
-		l.sendStarted = true
-	}
-}
-
-// StartLevel starts the
+// StartLevel starts the given level if not started already. It sends
+// our best signature for this level up to CandidateCount peers.
 func (h *Handel) StartLevel(level int) {
 	h.Lock()
 	defer h.Unlock()
@@ -309,7 +299,7 @@ func (h *Handel) StartLevel(level int) {
 		return
 	}
 	lvl.setStarted()
-	h.sendUpdate(lvl, 1)
+	h.sendUpdate(lvl, h.c.CandidateCount)
 }
 
 // Send our best signature set for this level, to 'count' nodes

--- a/handel_test.go
+++ b/handel_test.go
@@ -34,8 +34,6 @@ func TestHandelTestNetworkFull(t *testing.T) {
 		{33, nil, 33, false},
 		{67, off(), 67, false},
 		{5, off(4), 4, false},
-		{13, off(0, 1, 4, 6), 6, false},
-		{128, off(0, 1, 4, 6), 124, false},
 		{10, off(0, 3, 5, 7, 9), 5, false},
 	}
 	testHandelTestNetwork(t, tests)
@@ -51,7 +49,8 @@ func TestHandelTestNetworkLarge(t *testing.T) {
 	off()
 
 	var tests = []handelTest{
-		{333, off(0, 1, 4, 6, 7, 19, 56, 89, 99), 310, false},
+		{223, off(0, 1, 4, 6, 7, 19, 56, 89, 99), 210, false},
+		{128, off(0, 1, 4, 6), 124, false},
 	}
 	testHandelTestNetwork(t, tests)
 }

--- a/handel_test.go
+++ b/handel_test.go
@@ -31,12 +31,14 @@ func TestHandelTestNetworkFull(t *testing.T) {
 	}
 
 	var tests = []handelTest{
-		{33, nil, 33, false},
-		{67, off(), 67, false},
-		{5, off(4), 4, false},
-		{13, off(0, 1, 4, 6), 6, false},
-		{128, off(0, 1, 4, 6), 124, false},
-		{10, off(0, 3, 5, 7, 9), 5, false},
+		{5, off(), 5, false},
+
+		/*     {33, nil, 33, false},*/
+		//{67, off(), 67, false},
+		//{5, off(4), 4, false},
+		//{13, off(0, 1, 4, 6), 6, false},
+		//{128, off(0, 1, 4, 6), 124, false},
+		/*{10, off(0, 3, 5, 7, 9), 5, false},*/
 	}
 	testHandelTestNetwork(t, tests)
 }
@@ -305,12 +307,13 @@ func TestHandelParsePacket(t *testing.T) {
 	registry := FakeRegistry(n)
 	//ids := registry.(*arrayRegistry).ids // TODO: The test runs ok even if we comment this lines
 	h := &Handel{
-		c:    DefaultConfig(n),
-		reg:  registry,
-		cons: new(fakeCons),
-		msg:  msg,
-		//part: NewBinPartitioner(ids[1].ID(), registry),
+		c:           DefaultConfig(n),
+		reg:         registry,
+		cons:        new(fakeCons),
+		msg:         msg,
+		Partitioner: NewBinPartitioner(1, registry),
 	}
+	h.levels = createLevels(registry, h.Partitioner)
 	type packetTest struct {
 		*Packet
 		Error bool
@@ -347,7 +350,8 @@ func TestHandelParsePacket(t *testing.T) {
 			}, false,
 		},
 	}
-	for _, test := range packets {
+	for i, test := range packets {
+		t.Logf(" -- test %d --", i)
 		_, err := h.parsePacket(test.Packet)
 		if test.Error {
 			require.Error(t, err)

--- a/handel_test.go
+++ b/handel_test.go
@@ -34,6 +34,8 @@ func TestHandelTestNetworkFull(t *testing.T) {
 		{33, nil, 33, false},
 		{67, off(), 67, false},
 		{5, off(4), 4, false},
+		{13, off(0, 1, 4, 6), 6, false},
+		{128, off(0, 1, 4, 6), 124, false},
 		{10, off(0, 3, 5, 7, 9), 5, false},
 	}
 	testHandelTestNetwork(t, tests)
@@ -49,8 +51,7 @@ func TestHandelTestNetworkLarge(t *testing.T) {
 	off()
 
 	var tests = []handelTest{
-		{223, off(0, 1, 4, 6, 7, 19, 56, 89, 99), 210, false},
-		{128, off(0, 1, 4, 6), 124, false},
+		{333, off(0, 1, 4, 6, 7, 19, 56, 89, 99), 310, false},
 	}
 	testHandelTestNetwork(t, tests)
 }

--- a/test.go
+++ b/test.go
@@ -50,7 +50,7 @@ func NewTest(keys []SecretKey, pubs []PublicKey, c Constructor, msg []byte) *Tes
 			return NewRandomBinPartitioner(id, reg, nil)
 			//return NewBinPartitioner(id, reg)
 		}
-		conf := &Config{NewPartitioner: newPartitioner, CandidateCount: 100}
+		conf := &Config{NewPartitioner: newPartitioner}
 		handels[i] = NewHandel(nets[i], reg, ids[i], c, msg, sigs[i], conf)
 	}
 	return &Test{

--- a/timeout.go
+++ b/timeout.go
@@ -1,0 +1,83 @@
+package handel
+
+import (
+	"sync"
+	"time"
+)
+
+// TimeoutStrategy decides when to start a level in Handel. It is started and
+// stopped by the Handel structure. A basic strategy starts level according to a
+// linear timeout function thanks to the Handel.StartLevel method. More advanced
+// strategies could for example implement the Pre/PostProcessor interface,
+// register itself as a processor to Handel, and start a level according to
+// specific rules such as "all nodes answered with a 1-contribution
+// multi-signature", etc.
+type TimeoutStrategy interface {
+	Start()
+	Stop()
+}
+
+type linearTimeout struct {
+	sync.Mutex
+	newLevel func(int)
+	maxLevel int
+	period   time.Duration
+	ticker   *time.Ticker
+	done     chan bool
+	started  bool
+}
+
+// DefaultLevelTimeout is the default level timeout used by the linear timeout
+// strategy.
+const DefaultLevelTimeout = 100 * time.Millisecond
+
+// NewDefaultLinearTimeout returns a TimeoutStrategy that starts level linearly
+// with the default period of DefaultLevelTimeout.  More precisely, level i
+// starts at time i * period.
+func NewDefaultLinearTimeout(h *Handel) TimeoutStrategy {
+	return NewLinearTimeout(h, DefaultLevelTimeout)
+}
+
+// NewLinearTimeout returns a TimeoutStrategy that starts level linearly with
+// the given period. More precisely, it starts level i at time i * period.
+func NewLinearTimeout(h *Handel, period time.Duration) TimeoutStrategy {
+	return &linearTimeout{
+		period:   period,
+		newLevel: h.StartLevel,
+		maxLevel: h.Partitioner.MaxLevel(),
+		done:     make(chan bool, 1),
+	}
+}
+
+func (l *linearTimeout) Start() {
+	l.Lock()
+	defer l.Unlock()
+	l.started = true
+	l.ticker = time.NewTicker(l.period)
+	// start first level directly if not done yet
+	l.newLevel(1)
+	go l.linearLevels(l.ticker.C)
+}
+
+func (l *linearTimeout) Stop() {
+	l.Lock()
+	defer l.Unlock()
+	if !l.started {
+		return
+	}
+	l.ticker.Stop()
+	close(l.done)
+}
+
+func (l *linearTimeout) linearLevels(c <-chan time.Time) {
+	level := 2
+	for level <= l.maxLevel {
+		select {
+		case <-c:
+			l.newLevel(level)
+			level++
+		case <-l.done:
+			return
+		}
+	}
+}

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,0 +1,47 @@
+package handel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutLinear(t *testing.T) {
+	n := 8
+	levels := 3
+	_, handels := FakeSetup(n)
+	h := handels[0]
+
+	period := 20 * time.Millisecond
+	tooLong := 30 * time.Millisecond
+	linear := NewLinearTimeout(h, period).(*linearTimeout)
+
+	chNewLevel := make(chan int, 1)
+	newLevel := func(level int) {
+		chNewLevel <- level
+	}
+	linear.newLevel = newLevel
+
+	go linear.Start()
+	level := 1
+	unfinished := true
+	for unfinished {
+		select {
+		case l := <-chNewLevel:
+			if l > levels {
+				t.FailNow()
+			}
+			require.Equal(t, level, l)
+			level++
+		case <-time.After(tooLong):
+			if level <= levels {
+				require.True(t, false, "waited too long time %d", level)
+			}
+			unfinished = false
+		}
+	}
+
+	// -1 because we increment even after the last one
+	require.Equal(t, levels, level-1)
+}

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -10,12 +10,13 @@ import (
 func TestTimeoutLinear(t *testing.T) {
 	n := 8
 	levels := 3
+	levelIDs := []int{1, 2, 3}
 	_, handels := FakeSetup(n)
 	h := handels[0]
 
 	period := 20 * time.Millisecond
 	tooLong := 30 * time.Millisecond
-	linear := NewLinearTimeout(h, period).(*linearTimeout)
+	linear := NewLinearTimeout(h, levelIDs, period).(*linearTimeout)
 
 	chNewLevel := make(chan int, 1)
 	newLevel := func(level int) {

--- a/utils.go
+++ b/utils.go
@@ -17,9 +17,17 @@ func min(x, y int) int {
 	return y
 }
 
-
 func pow2(n int) int {
 	return int(math.Pow(2, float64(n)))
+}
+
+func isContained(arr []int, v int) bool {
+	for _, v2 := range arr {
+		if v2 == v {
+			return true
+		}
+	}
+	return false
 }
 
 // isSet returns true if the bit is set to 1 at the given index in the binary


### PR DESCRIPTION
This PR brings the possibility to implement different timeout strategies by the `TimeoutStrategy` interface. It removed the dependencies between a timeout and the periodic update loop: the periodic update sends update to `UpdateCount` nodes and the timeout strategy starts levels whenever it calls `handel.StartLevel` - they are not linked anymore. I implemented the linear strategy where a level `i` starts at time `(i-1) * period`.
The "Large" test takes ~15 sec less to finish - however I am not sure why. 

Most interesting file: https://github.com/ConsenSys/handel/pull/43/files#diff-29ab279673319852ab49d129add50be5