### PR TITLE
Bscore

### DIFF
--- a/handel.go
+++ b/handel.go
@@ -441,6 +441,9 @@ func (h *Handel) checkCompletedLevel(s *sigPair) {
 	}
 
 	sp, _ := h.store.Best(s.level)
+	if sp == nil {
+		panic("we should have received the best signature, we got nil!")
+	}
 	if sp.Cardinality() == len(lvl.nodes) {
 		h.log.Debug("level_complete", s.level)
 		lvl.rcvCompleted = true
@@ -504,6 +507,9 @@ func (h *Handel) parsePacket(p *Packet) (*MultiSignature, error) {
 	}
 	if ms.BitLength() != len(lvl.nodes) {
 		return nil, errors.New("invalid bitset's size for given level")
+	}
+	if ms.None() {
+		return nil, errors.New("no signatures in the bitset")
 	}
 	return ms, err
 }

--- a/handel_test.go
+++ b/handel_test.go
@@ -211,14 +211,14 @@ func TestHandelCheckCompletedLevel(t *testing.T) {
 
 	sig0 := fullSigPair(1)
 	// not-complete signature
-	sig02 := fullSigPair(1)
-	sig02.ms.BitSet.Set(0, false)
+	sig02 := fullSigPair(2)
+	sig02.ms.BitSet.Set(0, true)
 
 	// node 0 corresponds to level 1 in node's 1 view.
 	// => store incomplete signature as if it was an empty signature from node 0
 	// node 1 should NOT send anything to node 2 (or 3 but we're only verifying
 	// node 2 since it will send to both anyway)
-	sender.store.Store(1, sig02.ms)
+	sender.store.Store(2, sig02.ms)
 	sender.checkCompletedLevel(sig02)
 	select {
 	case <-inc2:

--- a/simul/config_example.toml
+++ b/simul/config_example.toml
@@ -6,8 +6,8 @@ MaxTimeout = "2m"
 Retrials = 1
 
 [[Runs]]
-    Nodes = 180
-    Threshold = 178
+    Nodes = 5
+    Threshold = 3
     Failing = 2
     Processes = 1
     [Runs.Handel]

--- a/simul/config_example.toml
+++ b/simul/config_example.toml
@@ -6,8 +6,8 @@ MaxTimeout = "2m"
 Retrials = 1
 
 [[Runs]]
-    Nodes = 5
-    Threshold = 3
+    Nodes = 180
+    Threshold = 178
     Failing = 2
     Processes = 1
     [Runs.Handel]

--- a/store_test.go
+++ b/store_test.go
@@ -101,9 +101,9 @@ func TestStoreReplace(t *testing.T) {
 		// empty
 		{s(), sc(), b(), 2, nil, false, nil},
 		// duplicate
-		{s(sig2, sig2), sc(1, 0), b(true, false), 2, sig2.ms, true, fullSig2},
+		{s(sig2, sig2), sc(999998, 0), b(true, false), 2, sig2.ms, true, fullSig2},
 		// highest
-		{s(sig0, sig1, sig2, sig3), sc(1, 1, 1, 1), b(true, true, true, true), 2, sig2.ms, true, fullSig3},
+		{s(sig0, sig1, sig2, sig3), sc(1000000, 999999, 999998, 999997), b(true, true, true, true), 2, sig2.ms, true, fullSig3},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Difficult to estimate the benefit: when we're faster we have less messages so less removals.
Here are a few tests: simul 180 nodes, threshold 178, 2 dead nodes
**before**
8.2s   7400 removed
7.5s 8600 removed
9.5s 9600 removed
8.5s 7800 removed
11.5s 12000 removed

**after**
7.8s  11000 removed
6s 6300 removed
8.5s 6500 removed
7.2s 9600 removed
5.7s 5800 removed

So it seems faster with the new version