### PR TITLE
rename NodeCount to FastPath

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,10 +25,9 @@ type Config struct {
 	// a given level.
 	UpdateCount int
 
-	// NodeCount indicates how many peers should we contact each time we
-	// send packets to Handel nodes in a given candidate set. New nodes are
-	// selected each time but no more than NodeCount.
-	NodeCount int
+	// FastPath indicates how many peers should we contact when a level gets
+	// completed.
+	FastPath int
 
 	// NewBitSet returns an empty bitset. This function is used to parse
 	// incoming packets containing bitsets.
@@ -70,7 +69,7 @@ func DefaultConfig(numberOfNodes int) *Config {
 	contributions := PercentageToContributions(DefaultContributionsPerc, numberOfNodes)
 	return &Config{
 		Contributions:        contributions,
-		NodeCount:            DefaultCandidateCount,
+		FastPath:             DefaultCandidateCount,
 		UpdatePeriod:         DefaultUpdatePeriod,
 		UpdateCount:          DefaultUpdateCount,
 		NewBitSet:            DefaultBitSet,
@@ -131,8 +130,8 @@ func mergeWithDefault(c *Config, size int) *Config {
 		n := PercentageToContributions(DefaultContributionsPerc, size)
 		c2.Contributions = n
 	}
-	if c.NodeCount == 0 {
-		c2.NodeCount = DefaultCandidateCount
+	if c.FastPath == 0 {
+		c2.FastPath = DefaultCandidateCount
 	}
 	if c.UpdatePeriod == 0*time.Second {
 		c2.UpdatePeriod = DefaultUpdatePeriod

--- a/handel.go
+++ b/handel.go
@@ -208,7 +208,7 @@ func (h *Handel) unsafeStartLevel(lvl *level) {
 		return
 	}
 	lvl.setStarted()
-	h.sendUpdate(lvl, h.c.NodeCount)
+	h.sendUpdate(lvl, h.c.UpdateCount)
 
 }
 
@@ -331,7 +331,7 @@ func (h *Handel) checkCompletedLevel(s *incomingSig) {
 		}
 		ms := h.store.Combined(byte(id) - 1)
 		if ms != nil && lvl.updateSigToSend(ms) {
-			h.sendUpdate(lvl, h.c.NodeCount)
+			h.sendUpdate(lvl, h.c.FastPath)
 		}
 	}
 }

--- a/simul/lib/config.go
+++ b/simul/lib/config.go
@@ -301,7 +301,7 @@ func (r *RunConfig) GetHandelConfig() *handel.Config {
 	}
 	ch.UpdatePeriod = period
 	ch.UpdateCount = r.Handel.UpdateCount
-	ch.NodeCount = r.Handel.NodeCount
+	ch.FastPath = r.Handel.NodeCount
 	ch.Contributions = r.GetThreshold()
 	ch.UnsafeSleepTimeOnSigVerify = r.Handel.UnsafeSleepTimeOnSigVerify
 


### PR DESCRIPTION
This variable should be name fastpath as it is used as such. As well, we
should only send to UpdateCount node when we send to a level.